### PR TITLE
Unify tooling: canonical air.toml, minimal .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
+# This file intentionally minimal — see ~/.config/git/ignore for global patterns.
 !data/
 !data/*.rda
 !data-raw/
-.RData
-.Rcheck
-.Rhistory
-.Rproj.user
-docs/

--- a/air.toml
+++ b/air.toml
@@ -1,8 +1,8 @@
 [format]
-default-exclude = true
+default-exclude = false
 exclude = []
 indent-style = "space"
 indent-width = 4
-line-ending = "auto"
+line-ending = "lf"
 line-width = 80
 persistent-line-breaks = true


### PR DESCRIPTION
- Standardize air.toml to Variant A (default-exclude=false, line-ending=lf)
- Replace .gitignore with minimal version (global ~/.config/git/ignore covers .RData, .Rcheck, docs/, _problems/)